### PR TITLE
Add islandora solr metadata tpl to override original 

### DIFF
--- a/bootstrap_digitalcollections/templates/islandora-dublin-core-display.tpl.php
+++ b/bootstrap_digitalcollections/templates/islandora-dublin-core-display.tpl.php
@@ -1,0 +1,33 @@
+<?php
+/**
+* @file
+* This is the template file for the object page for large image
+*
+* Available variables:
+* - $islandora_object: The Islandora object rendered in this template file
+* - $islandora_dublin_core: The DC datastream object
+* - $dc_array: The DC datastream object values as a sanitized array. This
+* includes label, value and class name.
+* - $islandora_object_label: The sanitized object label.
+*
+* @see template_preprocess_islandora_dublin_core_display()
+* @see theme_islandora_dublin_core_display()
+*/
+?>
+<fieldset <?php $print ? print('class="islandora islandora-metadata"') : print('class="islandora islandora-metadata"');?>>
+  <legend><span class="fieldset-legend"><a data-toggle="collapse" data-parent=".islandora-metadata-fields" href=".islandora-metadata-fields"><?php print t('Details'); ?></a></span></legend>
+  <div class="fieldset-wrapper">
+    <dl xmlns:dcterms="http://purl.org/dc/terms/" class="islandora-inline-metadata islandora-metadata-fields islandora-object-fields collapse">
+      <?php $row_field = 0; ?>
+      <?php foreach($dc_array as $key => $value): ?>
+        <dt property="<?php print $value['dcterms']; ?>" content="<?php print filter_xss(htmlspecialchars($value['value'], ENT_QUOTES, 'UTF-8')); ?>" class="<?php print $value['class']; ?><?php print $row_field == 0 ? ' first' : ''; ?>">
+          <?php print filter_xss($value['label']); ?>
+        </dt>
+        <dd class="<?php print $value['class']; ?><?php print $row_field == 0 ? ' first' : ''; ?>">
+          <?php print filter_xss($value['value']); ?>
+        </dd>
+        <?php $row_field++; ?>
+      <?php endforeach; ?>
+    </dl>
+  </div>
+</fieldset>

--- a/bootstrap_digitalcollections/templates/islandora-solr-metadata-display.tpl.php
+++ b/bootstrap_digitalcollections/templates/islandora-solr-metadata-display.tpl.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @file
+ * Islandora_solr_metadata display template.
+ *
+ * Variables available:
+ * - $solr_fields: Array of results returned from Solr for the current object
+ *   based upon defined display configuration(s). The array structure is:
+ *   - display_label: The defined display label corresponding to the Solr field
+ *     as defined in the configuration in translatable string form.
+ *   - value: An array containing all the result(s) found for the specific field
+ *     in Solr for the current object when queried against Solr.
+ * - $found: Boolean indicating if a Solr doc was found for the current object.
+ * - $not_found_message: A string to print if there was no document found in
+ *   Solr.
+ *
+ * @see template_preprocess_islandora_solr_metadata_display()
+ * @see template_process_islandora_solr_metadata_display()
+ */
+?>
+<?php if ($found):
+  if (!(empty($solr_fields) && variable_get('islandora_solr_metadata_omit_empty_values', FALSE))):?>
+<fieldset <?php $print ? print('class="islandora islandora-metadata"') : print('class="islandora islandora-metadata"');?>>
+  <legend><span class="fieldset-legend"><a data-toggle="collapse" data-parent="#accordion" href=".islandora-metadata-fields"><?php print t('Details'); ?></a></span></legend>
+  <div class="fieldset-wrapper">
+    <dl xmlns:dcterms="http://purl.org/dc/terms/" class="islandora-inline-metadata islandora-metadata-fields collapse">
+      <?php $row_field = 0; ?>
+      <?php foreach($solr_fields as $value): ?>
+        <dt class="<?php print $row_field == 0 ? ' first' : ''; ?>">
+          <?php print $value['display_label']; ?>
+        </dt>
+        <dd class="<?php print $row_field == 0 ? ' first' : ''; ?>">
+          <?php print check_markup(implode($variables['separator'], $value['value']), 'islandora_solr_metadata_filtered_html'); ?>
+        </dd>
+        <?php $row_field++; ?>
+      <?php endforeach; ?>
+    </dl>
+  </div>
+</fieldset>
+<?php endif; ?>
+<?php else: ?>
+  <fieldset <?php $print ? print('class="islandora islandora-metadata"') : print('class="islandora islandora-metadata collapsible collapsed"');?>>
+    <legend><span class="fieldset-legend"><?php print t('Details'); ?></span></legend>
+    <?php //XXX: Hack in markup for message. ?>
+    <div class="messages--warning messages warning">
+      <?php print $not_found_message; ?>
+    </div>
+  </fieldset>
+<?php endif; ?>

--- a/bootstrap_digitalcollections/templates/islandora-solr-metadata-display.tpl.php
+++ b/bootstrap_digitalcollections/templates/islandora-solr-metadata-display.tpl.php
@@ -21,7 +21,7 @@
 <?php if ($found):
   if (!(empty($solr_fields) && variable_get('islandora_solr_metadata_omit_empty_values', FALSE))):?>
 <fieldset <?php $print ? print('class="islandora islandora-metadata"') : print('class="islandora islandora-metadata"');?>>
-  <legend><span class="fieldset-legend"><a data-toggle="collapse" data-parent="#accordion" href=".islandora-metadata-fields"><?php print t('Details'); ?></a></span></legend>
+  <legend><span class="fieldset-legend"><a data-toggle="collapse" data-parent=".islandora-metadata-fields" href=".islandora-metadata-fields"><?php print t('Details'); ?></a></span></legend>
   <div class="fieldset-wrapper">
     <dl xmlns:dcterms="http://purl.org/dc/terms/" class="islandora-inline-metadata islandora-metadata-fields collapse">
       <?php $row_field = 0; ?>


### PR DESCRIPTION
# What does this Pull Request do?
This pull request will address the collapsible issue experienced when working with Islandora Solr Metadata Display. 

# How should this be tested?
### Before merging code:

* Create an Islandora Solr Metadata Display configuration.
* Associate with a content model and save configuration.
* Navigate to an object of the selected content model. Observe details.
         > User is unable to click _Details_ to expand metadata display

### After merging code:
* Repeat last step.
         > _Details_ will now be a clickable link. When clicked, it will toggle the display of the metadata.

# Screenshots
## Before Screenshot
![image](https://user-images.githubusercontent.com/22577721/50526247-2e160a00-0ab7-11e9-87e9-6c700c9f2d38.png)

## After Screenshot
![image](https://user-images.githubusercontent.com/22577721/50526370-f491ce80-0ab7-11e9-88bc-9759537d5735.png)
----
Elkeno Jones
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
